### PR TITLE
feat: Replaced Irys SDK with Turbo SDK for uploading assets to Arweave, Manifest v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ To deploy your application, ensure you have a build script and a deployment scri
 
 Replace `<ANT_PROCESS>` with your actual ANT process.
 
+#### Turbo
+To deploy your application using Turbo, simply add a `-t` or `--turbo` flag when running your deploy script:
+
+```json
+"scripts": {
+    "build": "your-build-command",
+    "deploy-turbo": "npm run build && permaweb-deploy --ant-process <ANT_PROCESS> -t"
+}
+```
+
+**NOTE**: This requires that the wallet provided as `DEPLOY_KEY` has [Turbo Credits](https://docs.ardrive.io/docs/turbo/what-is-turbo.html) to pay for the upload.
+
 ### GitHub Actions Workflow
 To automate the deployment, set up a GitHub Actions workflow as follows:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -34,18 +34,6 @@ To deploy your application, ensure you have a build script and a deployment scri
 
 Replace `<ANT_PROCESS>` with your actual ANT process.
 
-#### Turbo
-To deploy your application using Turbo, simply add a `-t` or `--turbo` flag when running your deploy script:
-
-```json
-"scripts": {
-    "build": "your-build-command",
-    "deploy-turbo": "npm run build && permaweb-deploy --ant-process <ANT_PROCESS> -t"
-}
-```
-
-**NOTE**: This requires that the wallet provided as `DEPLOY_KEY` has [Turbo Credits](https://docs.ardrive.io/docs/turbo/what-is-turbo.html) to pay for the upload.
-
 ### GitHub Actions Workflow
 To automate the deployment, set up a GitHub Actions workflow as follows:
 ```yaml

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
 		"permaweb-deploy": "./dist/index.js"
 	},
 	"dependencies": {
-		"@ar.io/sdk": "1.2.0",
+		"@ar.io/sdk": "^1.2.2",
+		"@ardrive/turbo-sdk": "^1.9.0",
 		"@irys/sdk": "0.1.1",
+		"mime-types": "^2.1.35",
 		"yargs": "17.7.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
 	"dependencies": {
 		"@ar.io/sdk": "^1.2.2",
 		"@ardrive/turbo-sdk": "^1.9.0",
-		"@irys/sdk": "0.1.1",
 		"mime-types": "^2.1.35",
 		"yargs": "17.7.2"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,6 @@ import fs from 'fs';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import Irys from '@irys/sdk';
-
 import TurboDeploy from './turbo';
 
 const argv = yargs(hideBin(process.argv))
@@ -27,12 +25,6 @@ const argv = yargs(hideBin(process.argv))
 		type: 'string',
 		description: 'ANT undername to update.',
 		default: '@',
-	})
-	.option('turbo', {
-		alias: 't',
-		type: 'boolean',
-		description: 'Enable upload with Turbo',
-		default: false,
 	}).argv;
 
 const DEPLOY_KEY = process.env.DEPLOY_KEY;
@@ -76,25 +68,8 @@ export function getTagValue(list, name) {
 	}
 
 	let jwk = JSON.parse(Buffer.from(DEPLOY_KEY, 'base64').toString('utf-8'));
-
-	if (argv.turbo){
-		TurboDeploy(argv, jwk)
-	}
-	else
-	{const irys = new Irys({ url: 'https://turbo.ardrive.io', token: 'arweave', key: jwk });
-	irys.uploader.useChunking = false;
-
 	try {
-		console.log(`Deploying ${argv.deployFolder} folder`);
-
-		const txResult = await irys.uploadFolder(argv.deployFolder, {
-			indexFile: 'index.html',
-			interactivePreflight: false,
-			logFunction: (log) => console.log(log),
-		});
-
-		console.log(`Bundle TxId [${txResult.id}]`);
-
+		const manifestId = await TurboDeploy(argv, jwk);
 		const signer = new ArweaveSigner(jwk);
 		const ant = ANT.init({ processId: ANT_PROCESS, signer });
 
@@ -102,17 +77,21 @@ export function getTagValue(list, name) {
 		await ant.setRecord(
 			{
 				undername: argv.undername,
-				transactionId: txResult.id,
+				transactionId: manifestId,
 				ttlSeconds: 3600,
 			},
 			{
 				name: 'GIT-HASH',
 				value: process.env.GITHUB_SHA,
+			},
+			{
+				name: 'App-Name',
+				value: 'Permaweb-Deploy',
 			}
 		);
 
-		console.log(`Deployed TxId [${txResult.id}] to ANT [${ANT_PROCESS}] using undername [${argv.undername}]`);
+		console.log(`Deployed TxId [${manifestId}] to ANT [${ANT_PROCESS}] using undername [${argv.undername}]`);
 	} catch (e) {
 		console.error(e);
-	}}
+	}
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import { hideBin } from 'yargs/helpers';
 
 import Irys from '@irys/sdk';
 
+import TurboDeploy from './turbo';
+
 const argv = yargs(hideBin(process.argv))
 	.option('ant-process', {
 		alias: 'a',
@@ -25,6 +27,12 @@ const argv = yargs(hideBin(process.argv))
 		type: 'string',
 		description: 'ANT undername to update.',
 		default: '@',
+	})
+	.option('turbo', {
+		alias: 't',
+		type: 'boolean',
+		description: 'Enable upload with Turbo',
+		default: false,
 	}).argv;
 
 const DEPLOY_KEY = process.env.DEPLOY_KEY;
@@ -69,7 +77,11 @@ export function getTagValue(list, name) {
 
 	let jwk = JSON.parse(Buffer.from(DEPLOY_KEY, 'base64').toString('utf-8'));
 
-	const irys = new Irys({ url: 'https://turbo.ardrive.io', token: 'arweave', key: jwk });
+	if (argv.turbo){
+		TurboDeploy(argv, jwk)
+	}
+	else
+	{const irys = new Irys({ url: 'https://turbo.ardrive.io', token: 'arweave', key: jwk });
 	irys.uploader.useChunking = false;
 
 	try {
@@ -102,5 +114,5 @@ export function getTagValue(list, name) {
 		console.log(`Deployed TxId [${txResult.id}] to ANT [${ANT_PROCESS}] using undername [${argv.undername}]`);
 	} catch (e) {
 		console.error(e);
-	}
+	}}
 })();

--- a/src/turbo/index.js
+++ b/src/turbo/index.js
@@ -1,0 +1,129 @@
+import { ANT } from '@ar.io/sdk';
+import { ArweaveSigner, TurboFactory } from '@ardrive/turbo-sdk';
+import fs from 'fs';
+import mime from 'mime-types';
+import path from 'path';
+import { Readable } from 'stream';
+
+// Gets MIME types for each file to tag the upload
+async function getContentType(filePath) {
+	return mime.lookup(filePath);
+}
+
+export default async function TurboDeploy(argv, jwk) {
+	const turbo = TurboFactory.authenticated({ privateKey: jwk });
+	const ant = ANT.init({
+		signer: new ArweaveSigner(jwk),
+		processId: argv.antProcess,
+	});
+
+	const deployFolder = argv.deployFolder;
+	//Uses Arweave manifest version 0.2.0, which supports fallbacks
+	let newManifest = {
+		manifest: 'arweave/paths',
+		version: '0.2.0',
+		index: { path: 'index.html' },
+		fallback: {},
+		paths: {},
+	};
+
+	async function processFiles(dir) {
+		const files = fs.readdirSync(dir);
+
+		for (const file of files) {
+			try {
+				const filePath = path.join(dir, file);
+				const relativePath = path.relative(deployFolder, filePath);
+
+				if (fs.statSync(filePath).isDirectory()) {
+					// recursively process all files in a directory
+					await processFiles(filePath);
+				} else {
+					console.log(`Uploading file: ${relativePath}`);
+					try {
+						const fileSize = fs.statSync(filePath).size;
+						const contentType = await getContentType(filePath);
+						const uploadResult = await turbo.uploadFile({
+							fileStreamFactory: () => fs.createReadStream(filePath),
+							fileSizeFactory: () => fileSize,
+							signal: AbortSignal.timeout(10_000), // cancel the upload after 10 seconds
+							dataItemOpts: {
+								tags: [
+									{ name: 'Content-Type', value: contentType },
+									{ name: 'App-Name', value: 'Permaweb-Deploy' },
+								],
+							},
+						});
+
+						console.log(`Uploaded ${relativePath} with id:`, uploadResult.id);
+						// adds uploaded file txId to the new manifest json
+						newManifest.paths[relativePath] = { id: uploadResult.id };
+
+						if (file === '404.html') {
+							// sets manifest fallback to 404.html if found
+							newManifest.fallback.id = uploadResult.id;
+						}
+					} catch (err) {
+						console.error(`Error uploading file ${relativePath}:`, err);
+					}
+				}
+			} catch (err) {
+				console.error('ERROR:', err);
+			}
+		}
+	}
+
+	async function uploadManifest(manifest) {
+		try {
+			const manifestString = JSON.stringify(manifest);
+			const uploadResult = await turbo.uploadFile({
+				fileStreamFactory: () => Readable.from(Buffer.from(manifestString)),
+				fileSizeFactory: () => Buffer.byteLength(manifestString),
+				signal: AbortSignal.timeout(10_000),
+				dataItemOpts: {
+					tags: [
+						{
+							name: 'Content-Type',
+							value: 'application/x.arweave-manifest+json',
+						},
+						{
+							name: 'App-Name',
+							value: 'Permaweb-Deploy',
+						},
+					],
+				},
+			});
+			return uploadResult.id;
+		} catch (error) {
+			console.error('Error uploading manifest:', error);
+			return null;
+		}
+	}
+
+	// starts processing files in the selected directory
+	await processFiles(deployFolder);
+
+	if (!newManifest.fallback.id) {
+		// if no 404.html file is found, manifest fallback is set to the txId of index.html
+		newManifest.fallback.id = newManifest.paths['index.html'].id;
+	}
+
+	const manifestId = await uploadManifest(newManifest);
+	if (manifestId) {
+		console.log(`Manifest uploaded with Id: ${manifestId}`);
+		try {
+			// sets the ArNS record
+			const recordSet = await ant.setRecord(
+				{
+					undername: argv.undername,
+					transactionId: manifestId,
+					ttlSeconds: 900,
+				},
+				{ tags: [{ name: 'App-Name', value: 'Permaweb-Deploy' }] }
+			);
+			console.log(`ArNS updated with txId: ${recordSet.id}`);
+		} catch (err) {
+			console.error('Error updating ArNS:', err);
+		}
+	}
+}

--- a/src/turbo/index.js
+++ b/src/turbo/index.js
@@ -1,5 +1,4 @@
-import { ANT } from '@ar.io/sdk';
-import { ArweaveSigner, TurboFactory } from '@ardrive/turbo-sdk';
+import { TurboFactory } from '@ardrive/turbo-sdk';
 import fs from 'fs';
 import mime from 'mime-types';
 import path from 'path';
@@ -12,10 +11,6 @@ async function getContentType(filePath) {
 
 export default async function TurboDeploy(argv, jwk) {
 	const turbo = TurboFactory.authenticated({ privateKey: jwk });
-	const ant = ANT.init({
-		signer: new ArweaveSigner(jwk),
-		processId: argv.antProcess,
-	});
 
 	const deployFolder = argv.deployFolder;
 	//Uses Arweave manifest version 0.2.0, which supports fallbacks
@@ -111,19 +106,6 @@ export default async function TurboDeploy(argv, jwk) {
 	const manifestId = await uploadManifest(newManifest);
 	if (manifestId) {
 		console.log(`Manifest uploaded with Id: ${manifestId}`);
-		try {
-			// sets the ArNS record
-			const recordSet = await ant.setRecord(
-				{
-					undername: argv.undername,
-					transactionId: manifestId,
-					ttlSeconds: 900,
-				},
-				{ tags: [{ name: 'App-Name', value: 'Permaweb-Deploy' }] }
-			);
-			console.log(`ArNS updated with txId: ${recordSet.id}`);
-		} catch (err) {
-			console.error('Error updating ArNS:', err);
-		}
+		return manifestId;
 	}
 }


### PR DESCRIPTION
This update removes the Irys SDK in favor of directly using the Turbo SDK for uploading assets to Arweave. This change integrates more functionality into the permaweb-deploy codebase, which was previously handled by Irys, providing greater visibility and transparency into the operations and processes involved in the uploads.

Additionally, the update implements the Arweave manifest syntax for version 0.2.0, which supports a "fallback" id. This feature allows for a functioning 404 page by specifying a fallback transaction id in the manifest. If a 404.html file is not found during the upload process, the transaction id for the index.html file will be used as the fallback.