### PR TITLE
updating default ttl to 60 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Replace `<ARNS_NAME>` with your ArNS name. To deploy to an undername, add `--und
 - `--deploy-folder, -d`: Folder to deploy. Default: `./dist`.
 - `--deploy-file, -f`: Deploy a single file instead of a folder.
 - `--undername, -u`: ANT undername to update. Default: `@`.
-- `--ttl-seconds, -t`: TTL in seconds for the ANT record (60-86400). Default: `3600`.
+- `--ttl-seconds, -t`: TTL in seconds for the ANT record (60-86400). Default: `60`.
 - `--sig-type, -s`: Signer type for deployment. Choices: `arweave`, `ethereum`, `polygon`, `kyve`. Default: `arweave`.
 - `--help`: Show all available options and usage examples.
 - `--version`: Show the current version number.

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ const argv = yargs(hideBin(process.argv))
 		alias: 't',
 		type: 'number',
 		description: 'ArNS TTL Seconds',
-		default: 3600,
+		default: 60,
 	})
 	.option('undername', {
 		alias: 'u',


### PR DESCRIPTION
This PR updates the default TTL value for ArNS from 3600 to 60 seconds so deployments re reflected faster on ArNS.

We've had a few teams report "Why isn't my ArNS updating" because the TTL was set to 3600 so they had to wait up to an hour for it to be reflected.

Tagging in our team to make sure they're cool with this @dtfiedler @atticusofsparta 