### PR TITLE
feat: hyperbeam bundler first class support hardening 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Permaweb Deploy
 
-Inspired by the [cookbook github action deployment guide](https://cookbook.arweave.dev/guides/deployment/github-action.html), `permaweb-deploy` is a Node.js command-line tool designed to streamline the deployment of web applications to the permaweb using Arweave. It uploads your build folder or a single file, creates Arweave manifests, and updates ArNS (Arweave Name Service) records via ANT (Arweave Name Token) with the transaction ID.
+Inspired by the [cookbook github action deployment guide](https://cookbook.arweave.dev/guides/deployment/github-action.html), `permaweb-deploy` is a Node.js command-line tool designed to streamline the deployment of web applications to the permaweb using Arweave. It uploads your build folder or a single file, creates Arweave manifests, and can optionally update ArNS (Arweave Name Service) records via ANT (Arweave Name Token) with the transaction ID.
 
 ## Features
 
 - **Turbo SDK Integration:** Uses Turbo SDK for fast, reliable file uploads to Arweave
 - **On-Demand Payment:** Pay with ARIO or Base-ETH tokens on-demand during upload
 - **Arweave Manifest v0.2.0:** Creates manifests with fallback support for SPAs
-- **ArNS Updates:** Updates ArNS records via ANT with new transaction IDs and metadata
+- **Optional ArNS Updates:** Updates ArNS records via ANT with new transaction IDs and metadata
 - **Automated Workflow:** Integrates with GitHub Actions for continuous deployment
 - **Git Hash Tagging:** Automatically tags deployments with Git commit hashes
 - **404 Fallback Detection:** Automatically detects and sets 404.html as fallback
@@ -77,7 +77,7 @@ Run the deploy command without arguments to be guided through all deployment opt
 permaweb-deploy deploy
 ```
 
-This will prompt you for:
+This uploads to the permaweb by default. Use `--use-arns` or `--arns-name` to run the guided ArNS update flow, which will prompt you for:
 
 - ArNS name
 - Wallet method (file, string, or environment variable)
@@ -91,7 +91,10 @@ Use flags for faster, scriptable deployments:
 
 ```bash
 # Basic deployment with wallet file
-permaweb-deploy deploy --arns-name my-app --wallet ./wallet.json
+permaweb-deploy deploy --wallet ./wallet.json
+
+# Deployment with ArNS update
+permaweb-deploy deploy --use-arns --arns-name my-app --wallet ./wallet.json
 ```
 
 Deploy using private key directly:
@@ -118,11 +121,12 @@ Deploy a single file:
 permaweb-deploy deploy --arns-name my-app --wallet ./wallet.json --deploy-file ./path/to/file.txt
 ```
 
-### Upload only (no ArNS)
+### Upload/deploy without ArNS
 
-To upload a folder or file to Arweave **without** updating an ArNS name, use the `upload` command (same Turbo upload, dedupe cache, and payment options as deploy, minus ArNS flags):
+`deploy` uploads without updating ArNS by default. You can also use the `upload` command explicitly for the same Turbo upload, dedupe cache, and payment options as deploy, minus ArNS flags:
 
 ```bash
+permaweb-deploy deploy --wallet ./wallet.json --deploy-folder ./dist
 permaweb-deploy upload --wallet ./wallet.json --deploy-folder ./dist
 permaweb-deploy upload --wallet ./wallet.json --deploy-file ./dist/index.html
 DEPLOY_KEY=$(base64 -i wallet.json) permaweb-deploy upload --deploy-folder ./dist
@@ -217,14 +221,13 @@ permaweb-deploy upload \
   --uploader https://hyperbeam.example.com
 
 permaweb-deploy deploy \
-  --arns-name my-app \
   --wallet ./wallet.json \
   --deploy-folder ./dist \
   --uploader-type hyperbeam \
   --uploader https://hyperbeam.example.com
 ```
 
-If the node follows the standard AO-paid HyperBEAM bundler flow, the CLI can fund the uploader wallet before uploading:
+If the node follows the standard AO-paid HyperBEAM bundler flow, either command can fund the uploader wallet before uploading:
 
 ```bash
 permaweb-deploy upload \
@@ -238,15 +241,16 @@ permaweb-deploy upload \
 **Notes:**
 
 - Turbo billing and signer behavior follow Turbo.
-- HyperBEAM uploads require an Arweave JWK signer. With `--hyperbeam-auto-fund`, the CLI signs each data item, asks the node's `metering@1.0` device for a byte quote, sends AO to the node address from `/~meta@1.0/info/address`, imports that deposit through `/~ao-payment@1.0/ingest`, and waits for the uploader's balance at `/ledger~node-process@1.0/now/balance/<address>` before uploading. The default route is `/~bundler@1.0/item?codec-device=ans104@1.0`; override it with `--hyperbeam-upload-path` if your node exposes a different bundler route.
-- `--hyperbeam-fund-amount` is an optional override for the minimum local ledger balance to ensure, in AO base units. Without it, `--hyperbeam-auto-fund` uses the node's `metering@1.0` quote for the signed byte count. Use `--hyperbeam-token-id` only for a non-default AO token process, and `--hyperbeam-ledger-id` only for a non-default local ledger profile.
+- HyperBEAM uploads require an Arweave JWK signer. Before uploading, the CLI checks the node address from `/~meta@1.0/info/address` against `https://arweave.net/wallet/<address>/balance` and aborts if the bundler wallet has 0 AR. With `--hyperbeam-auto-fund`, the CLI signs each data item, asks the node's byte-pricing profile for a quote, sends AO to the node deposit address, imports that deposit through `/~ao-payment@1.0/ingest`, and waits for the uploader's balance at `/ledger~node-process@1.0/now/balance/<address>` before uploading. The default route is `/~bundler@1.0/item?codec-device=ans104@1.0`; override it with `--hyperbeam-upload-path` if your node exposes a different bundler route.
+- `--hyperbeam-fund-amount` is an optional override for the minimum local ledger balance to ensure, in AO base units. Without it, `--hyperbeam-auto-fund` uses the node's byte-pricing quote for the signed byte count. Use `--hyperbeam-token-id` only for a non-default AO token process, and `--hyperbeam-ledger-id` only for a non-default local ledger profile.
 - Use a **base URL only** (e.g. `https://up.arweave.net` or `https://hyperbeam.example.com`), not a path to a specific file or route.
 
 ### Command Options
 
-**`deploy`** (ArNS update):
+**`deploy`** (upload by default, optional ArNS update):
 
-- `--arns-name, -n` (required): The ArNS name to update
+- `--use-arns`: Update an ArNS/ANT record after upload
+- `--arns-name, -n`: The ArNS name to update. Required when using `--use-arns`; also implies ArNS mode for backwards compatibility.
 - `--ario-process, -p`: ARIO process to use (`mainnet`, `testnet`, or a custom process ID). Default: `mainnet`
 - `--deploy-folder, -d`: Folder to deploy. Default: `./dist`
 - `--deploy-file, -f`: Deploy a single file instead of a folder
@@ -268,7 +272,7 @@ permaweb-deploy upload \
 - `--hyperbeam-ledger-id`: Advanced local HyperBEAM ledger ID override
 - `--hyperbeam-ao-state-url`: AO state endpoint used while waiting for auto-fund transfer assignment. Default: `https://state.forward.computer`
 
-**`upload`** (no ArNS): accepts `--deploy-folder`, `--deploy-file`, wallet/signer flags, uploader flags, `--on-demand` / `--max-token-amount`, and dedupe flags only.
+**`upload`** (explicit upload without ArNS): accepts `--deploy-folder`, `--deploy-file`, wallet/signer flags, uploader flags, `--on-demand` / `--max-token-amount`, and dedupe flags only.
 
 ### Deduplication
 
@@ -617,7 +621,7 @@ permaweb-deploy/
 
 - **Dedicated Wallet:** Always use a dedicated wallet for deployments to minimize security risks
 - **Wallet Encoding:** Arweave wallets must be base64 encoded to be used in the deployment script
-- **ArNS Name:** The ArNS Name must be passed so that the ANT Process can be resolved to update the target undername or root record
+- **ArNS Name:** Required only when updating an ANT/ArNS target undername or root record
 - **Turbo Credits:** Ensure your wallet has sufficient Turbo Credits, or use on-demand payment for automatic funding
 - **On-Demand Limits:** Set reasonable `--max-token-amount` limits to prevent unexpected costs
 - **Secret Management:** Keep your `DEPLOY_KEY` secret secure and never commit it to your repository

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -22,20 +22,15 @@ import { runUploadWorkflow } from '../workflows/upload-workflow.js'
 export default class Deploy extends Command {
   static override args = {}
 
-  static override description = 'Deploy your application to the permaweb'
+  static override description = 'Deploy an application to the permaweb with optional ArNS update'
 
   static override examples = [
-    '<%= config.bin %> deploy  # Interactive mode',
-    '<%= config.bin %> deploy --arns-name my-app --wallet ./wallet.json',
-    '<%= config.bin %> deploy --arns-name my-app --private-key "$(cat wallet.json)"',
-    '<%= config.bin %> deploy --arns-name my-app --undername staging',
-    '<%= config.bin %> deploy --arns-name my-app --deploy-file ./dist/index.html',
-    '<%= config.bin %> deploy --arns-name my-app --sig-type ethereum --wallet ./private-key.txt',
-    '<%= config.bin %> deploy --arns-name my-app --sig-type ethereum --private-key "0x..."',
-    '<%= config.bin %> deploy --arns-name my-app --on-demand ario --max-token-amount 1000',
-    '<%= config.bin %> deploy --arns-name my-app --uploader https://up.arweave.net',
-    '<%= config.bin %> deploy --arns-name my-app --uploader-type hyperbeam --uploader https://hyperbeam.example.com',
-    '<%= config.bin %> upload --wallet ./wallet.json  # Upload only (no ArNS update)',
+    '<%= config.bin %> deploy --wallet ./wallet.json',
+    '<%= config.bin %> deploy --wallet ./wallet.json --deploy-folder ./dist',
+    '<%= config.bin %> deploy --wallet ./wallet.json --deploy-file ./dist/index.html',
+    '<%= config.bin %> deploy --wallet ./wallet.json --uploader-type hyperbeam --uploader https://hyperbeam.example.com',
+    '<%= config.bin %> deploy --wallet ./wallet.json --use-arns --arns-name my-app',
+    '<%= config.bin %> deploy --wallet ./wallet.json --use-arns --arns-name my-app --undername staging',
   ]
 
   static override flags = extractFlags(deployFlagConfigs)
@@ -44,10 +39,11 @@ export default class Deploy extends Command {
     try {
       const { flags } = await this.parse(Deploy)
 
-      const interactive = !flags['arns-name']
+      const useArns = Boolean(flags['use-arns'] || flags['arns-name'])
+      const interactive = useArns && !flags['arns-name']
 
       if (interactive) {
-        this.log(chalk.cyan.bold('\nInteractive Deployment Mode\n'))
+        this.log(chalk.cyan.bold('\nInteractive ArNS Deployment Mode\n'))
       }
 
       const baseConfig = (await resolveConfig<typeof deployFlagConfigs>(deployFlagConfigs, flags, {
@@ -59,7 +55,12 @@ export default class Deploy extends Command {
         wallet: baseConfig.wallet,
       }
 
-      if (interactive && !baseConfig.wallet && !baseConfig['private-key']) {
+      const shouldPromptWallet =
+        !baseConfig.wallet &&
+        !baseConfig['private-key'] &&
+        (interactive || !process.env.DEPLOY_KEY?.trim())
+
+      if (shouldPromptWallet) {
         const config = await getWalletConfig()
         walletConfig = {
           privateKey: config.privateKey,
@@ -107,6 +108,7 @@ export default class Deploy extends Command {
         undername: advancedOptions?.undername || baseConfig.undername,
         uploader: baseConfig.uploader,
         'uploader-type': baseConfig['uploader-type'],
+        'use-arns': useArns,
         wallet: walletConfig.wallet,
       }
 
@@ -140,10 +142,86 @@ export default class Deploy extends Command {
         }
       }
 
-      const arioProcess = deployConfig['ario-process']
-
       this.log(chalk.cyan.bold('\nStarting deployment...\n'))
       try {
+        if (!deployConfig['use-arns']) {
+          const { transactionId: txOrManifestId } = await runUploadWorkflow(
+            deployKey,
+            deployConfig,
+            {
+              error: (msg) => this.error(msg),
+            },
+          )
+
+          this.log('')
+
+          const isCI = Boolean(process.env.CI)
+          const bundlerLink =
+            deployConfig['uploader-type'] === 'hyperbeam' && deployConfig.uploader
+              ? hyperbeamBundlerLink(
+                  deployConfig.uploader,
+                  txOrManifestId,
+                  !deployConfig['deploy-file'],
+                )
+              : undefined
+
+          if (isCI) {
+            this.log('Deployment Successful!')
+            this.log('Tx ID: ' + txOrManifestId)
+            if (deployConfig.uploader) {
+              this.log('Bundler service: ' + deployConfig.uploader)
+              this.log('Uploader type: ' + deployConfig['uploader-type'])
+            }
+
+            if (bundlerLink) {
+              this.log('Bundler link: ' + bundlerLink)
+            }
+
+            this.log(`Arweave URL: https://arweave.net/${txOrManifestId}`)
+          } else {
+            const table = new Table({
+              style: {
+                head: [],
+              },
+            })
+
+            table.push(
+              ['Tx ID', chalk.green(txOrManifestId)],
+              ...(deployConfig.uploader
+                ? ([
+                    ['Bundler service', chalk.cyan(deployConfig.uploader)],
+                    ['Uploader type', chalk.cyan(deployConfig['uploader-type'])],
+                  ] as [string, string][])
+                : []),
+              ...(bundlerLink
+                ? ([['Bundler link', chalk.yellow(bundlerLink)]] as [string, string][])
+                : []),
+              ['Arweave URL', chalk.yellow(`https://arweave.net/${txOrManifestId}`)],
+            )
+
+            const successMessage = boxen(
+              `${chalk.green.bold('Deployment Successful!')}\n\n${table.toString()}`,
+              {
+                borderColor: 'green',
+                borderStyle: 'round',
+                padding: 1,
+                title: chalk.bold('Permaweb Deploy'),
+                titleAlignment: 'center',
+              },
+            )
+
+            this.log(`\n${successMessage}`)
+          }
+
+          return
+        }
+
+        const arioProcess = deployConfig['ario-process']
+        const arnsName = deployConfig['arns-name']
+        if (!arnsName) {
+          this.error('--use-arns requires --arns-name')
+        }
+
         const spinner = ora()
 
         spinner.start('Initializing ARIO')
@@ -163,15 +241,13 @@ export default class Deploy extends Command {
 
         spinner.succeed('ARIO initialized')
 
-        spinner.start(`Fetching ArNS record for ${chalk.yellow(deployConfig['arns-name'])}`)
-        const arnsNameRecord = await ario
-          .getArNSRecord({ name: deployConfig['arns-name'] })
-          .catch(() => {
-            spinner.fail(`ArNS name ${chalk.red(deployConfig['arns-name'])} does not exist`)
-            this.error(`ArNS name [${deployConfig['arns-name']}] does not exist`)
-          })
+        spinner.start(`Fetching ArNS record for ${chalk.yellow(arnsName)}`)
+        const arnsNameRecord = await ario.getArNSRecord({ name: arnsName }).catch(() => {
+          spinner.fail(`ArNS name ${chalk.red(arnsName)} does not exist`)
+          this.error(`ArNS name [${arnsName}] does not exist`)
+        })
 
-        spinner.succeed(`ArNS record fetched for ${chalk.green(deployConfig['arns-name'])}`)
+        spinner.succeed(`ArNS record fetched for ${chalk.green(arnsName)}`)
 
         const { transactionId: txOrManifestId } = await runUploadWorkflow(deployKey, deployConfig, {
           error: (msg) => this.error(msg),
@@ -212,7 +288,11 @@ export default class Deploy extends Command {
         const isCI = Boolean(process.env.CI)
         const bundlerLink =
           deployConfig['uploader-type'] === 'hyperbeam' && deployConfig.uploader
-            ? hyperbeamBundlerLink(deployConfig.uploader, txOrManifestId)
+            ? hyperbeamBundlerLink(
+                deployConfig.uploader,
+                txOrManifestId,
+                !deployConfig['deploy-file'],
+              )
             : undefined
 
         if (isCI) {
@@ -227,7 +307,7 @@ export default class Deploy extends Command {
             this.log('Bundler link: ' + bundlerLink)
           }
 
-          this.log('ArNS Name: ' + deployConfig['arns-name'])
+          this.log('ArNS Name: ' + arnsName)
           this.log('Undername: ' + deployConfig.undername)
           this.log('ANT: ' + arnsNameRecord.processId)
           this.log('ARIO Process: ' + arioProcess)
@@ -235,7 +315,6 @@ export default class Deploy extends Command {
           this.log(`Arweave URL: https://arweave.net/${txOrManifestId}`)
         } else {
           const table = new Table({
-            head: [chalk.cyan.bold('Property'), chalk.cyan.bold('Value')],
             style: {
               head: [],
             },
@@ -252,7 +331,7 @@ export default class Deploy extends Command {
             ...(bundlerLink
               ? ([['Bundler link', chalk.yellow(bundlerLink)]] as [string, string][])
               : []),
-            ['ArNS Name', chalk.yellow(deployConfig['arns-name'])],
+            ['ArNS Name', chalk.yellow(arnsName)],
             ['Undername', chalk.yellow(deployConfig.undername)],
             ['ANT', chalk.cyan(arnsNameRecord.processId)],
             ['ARIO Process', chalk.gray(arioProcess)],

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -14,6 +14,7 @@ import { promptAdvancedOptions } from '../prompts/arns.js'
 import { getWalletConfig } from '../prompts/wallet.js'
 import type { SignerType } from '../types/index.js'
 import { extractFlags, resolveConfig } from '../utils/config-resolver.js'
+import { uploadErrorTable } from '../utils/display.js'
 import { hyperbeamBundlerLink } from '../utils/hyperbeam-uploader.js'
 import { expandPath } from '../utils/path.js'
 import { createSigner } from '../utils/signer.js'
@@ -353,9 +354,17 @@ export default class Deploy extends Command {
           this.log(`\n${successMessage}`)
         }
       } catch (error) {
-        this.error(
-          chalk.red(`Deployment failed: ${error instanceof Error ? error.message : String(error)}`),
-        )
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        const normalizedError = errorMessage.startsWith('Upload failed:')
+          ? errorMessage.replace(/^Upload failed:\s*/, '')
+          : errorMessage
+
+        if (errorMessage.startsWith('Upload failed:') && !process.env.CI && process.stdout.isTTY) {
+          this.log(`\n${uploadErrorTable(normalizedError, 'Deployment failed')}`)
+          this.exit(1)
+        }
+
+        this.error(chalk.red(`Deployment failed: ${errorMessage}`))
       }
     } catch (error) {
       if (error instanceof Error && error.name === 'ExitPromptError') {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -173,7 +173,7 @@ export default class Deploy extends Command {
 
         spinner.succeed(`ArNS record fetched for ${chalk.green(deployConfig['arns-name'])}`)
 
-        const txOrManifestId = await runUploadWorkflow(deployKey, deployConfig, {
+        const { transactionId: txOrManifestId } = await runUploadWorkflow(deployKey, deployConfig, {
           error: (msg) => this.error(msg),
         })
 

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -120,6 +120,7 @@ export default class Upload extends Command {
         this.log('')
 
         const isCI = Boolean(process.env.CI)
+        const uploadSize = uploadResult.size
         const bundlerLink =
           uploadCfg['uploader-type'] === 'hyperbeam' && uploadCfg.uploader
             ? hyperbeamBundlerLink(uploadCfg.uploader, txOrManifestId, !uploadCfg['deploy-file'])
@@ -128,8 +129,8 @@ export default class Upload extends Command {
         if (isCI) {
           this.log('Upload successful!')
           this.log('Tx ID: ' + txOrManifestId)
-          if (uploadResult.size) {
-            this.log('Upload size: ' + formatUploadSize(uploadResult.size))
+          if (uploadSize) {
+            this.log('Upload size: ' + formatUploadSize(uploadSize))
           }
 
           if (uploadResult.cost) {
@@ -152,8 +153,8 @@ export default class Upload extends Command {
           })
 
           table.push(['Tx ID', chalk.green(txOrManifestId)])
-          if (uploadResult.size) {
-            table.push(['Upload size', chalk.blue(formatUploadSize(uploadResult.size))])
+          if (uploadSize) {
+            table.push(['Upload size', chalk.blue(formatUploadSize(uploadSize))])
           }
 
           if (uploadResult.cost) {

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -9,66 +9,10 @@ import Table from 'cli-table3'
 import { type UploadConfig, uploadFlagConfigs } from '../constants/flags.js'
 import { getWalletConfig } from '../prompts/wallet.js'
 import { extractFlags, resolveConfig } from '../utils/config-resolver.js'
-import { formatUploadCost, formatUploadSize } from '../utils/display.js'
+import { formatUploadCost, formatUploadSize, uploadErrorTable } from '../utils/display.js'
 import { hyperbeamBundlerLink } from '../utils/hyperbeam-uploader.js'
 import { expandPath } from '../utils/path.js'
 import { runUploadWorkflow } from '../workflows/upload-workflow.js'
-
-function fundingDisplay(section: string): string {
-  const fundingLine = section
-    .split('\n')
-    .map((line) => line.trim())
-    .find((line) => line.startsWith('- '))
-    ?.replace(/^- /, '')
-
-  if (!fundingLine) {
-    return section
-  }
-
-  return fundingLine
-    .replace(/^AO: send funds to /, 'Sending AO to ')
-    .replace(/\. Local ledger:.*$/, '')
-}
-
-function uploadErrorTable(message: string): string {
-  const table = new Table({
-    style: { head: [] },
-  })
-  const sections = message
-    .split(/\n{2,}/)
-    .map((section) => section.trim())
-    .filter(Boolean)
-
-  for (const [index, section] of sections.entries()) {
-    if (index === 0) {
-      table.push(['Error', chalk.red(section)])
-      continue
-    }
-
-    if (section.startsWith('Required upload credit:')) {
-      table.push([
-        'Required upload credit',
-        chalk.blue(section.replace(/^Required upload credit:\s*/, '')),
-      ])
-      continue
-    }
-
-    if (section.startsWith('The HyperBEAM node requires AO')) {
-      table.push(['Funding', fundingDisplay(section)])
-      continue
-    }
-
-    table.push(['Note', section])
-  }
-
-  return boxen(`${chalk.red.bold('Upload failed')}\n\n${table.toString()}`, {
-    borderColor: 'red',
-    borderStyle: 'round',
-    padding: 1,
-    title: chalk.bold('Permaweb Deploy'),
-    titleAlignment: 'center',
-  })
-}
 
 export default class Upload extends Command {
   static override args = {}

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -9,9 +9,66 @@ import Table from 'cli-table3'
 import { type UploadConfig, uploadFlagConfigs } from '../constants/flags.js'
 import { getWalletConfig } from '../prompts/wallet.js'
 import { extractFlags, resolveConfig } from '../utils/config-resolver.js'
+import { formatUploadCost, formatUploadSize } from '../utils/display.js'
 import { hyperbeamBundlerLink } from '../utils/hyperbeam-uploader.js'
 import { expandPath } from '../utils/path.js'
 import { runUploadWorkflow } from '../workflows/upload-workflow.js'
+
+function fundingDisplay(section: string): string {
+  const fundingLine = section
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('- '))
+    ?.replace(/^- /, '')
+
+  if (!fundingLine) {
+    return section
+  }
+
+  return fundingLine
+    .replace(/^AO: send funds to /, 'Sending AO to ')
+    .replace(/\. Local ledger:.*$/, '')
+}
+
+function uploadErrorTable(message: string): string {
+  const table = new Table({
+    style: { head: [] },
+  })
+  const sections = message
+    .split(/\n{2,}/)
+    .map((section) => section.trim())
+    .filter(Boolean)
+
+  for (const [index, section] of sections.entries()) {
+    if (index === 0) {
+      table.push(['Error', chalk.red(section)])
+      continue
+    }
+
+    if (section.startsWith('Required upload credit:')) {
+      table.push([
+        'Required upload credit',
+        chalk.blue(section.replace(/^Required upload credit:\s*/, '')),
+      ])
+      continue
+    }
+
+    if (section.startsWith('The HyperBEAM node requires AO')) {
+      table.push(['Funding', fundingDisplay(section)])
+      continue
+    }
+
+    table.push(['Note', section])
+  }
+
+  return boxen(`${chalk.red.bold('Upload failed')}\n\n${table.toString()}`, {
+    borderColor: 'red',
+    borderStyle: 'round',
+    padding: 1,
+    title: chalk.bold('Permaweb Deploy'),
+    titleAlignment: 'center',
+  })
+}
 
 export default class Upload extends Command {
   static override args = {}
@@ -111,9 +168,10 @@ export default class Upload extends Command {
       this.log(chalk.cyan.bold('\nStarting upload...\n'))
 
       try {
-        const txOrManifestId = await runUploadWorkflow(deployKey, uploadCfg, {
+        const uploadResult = await runUploadWorkflow(deployKey, uploadCfg, {
           error: (msg) => this.error(msg),
         })
+        const txOrManifestId = uploadResult.transactionId
 
         this.log('')
 
@@ -126,6 +184,14 @@ export default class Upload extends Command {
         if (isCI) {
           this.log('Upload successful!')
           this.log('Tx ID: ' + txOrManifestId)
+          if (uploadResult.size > 0) {
+            this.log('Upload size: ' + formatUploadSize(uploadResult.size))
+          }
+
+          if (uploadResult.cost) {
+            this.log('Upload cost: ' + formatUploadCost(uploadResult.cost))
+          }
+
           if (uploadCfg.uploader) {
             this.log('Bundler service: ' + uploadCfg.uploader)
             this.log('Uploader type: ' + uploadCfg['uploader-type'])
@@ -138,11 +204,17 @@ export default class Upload extends Command {
           this.log(`Arweave URL: https://arweave.net/${txOrManifestId}`)
         } else {
           const table = new Table({
-            head: [chalk.cyan.bold('Property'), chalk.cyan.bold('Value')],
             style: { head: [] },
           })
 
           table.push(['Tx ID', chalk.green(txOrManifestId)])
+          if (uploadResult.size > 0) {
+            table.push(['Upload size', chalk.blue(formatUploadSize(uploadResult.size))])
+          }
+
+          if (uploadResult.cost) {
+            table.push(['Upload cost', chalk.blue(formatUploadCost(uploadResult.cost))])
+          }
 
           if (uploadCfg.uploader) {
             table.push(
@@ -171,8 +243,22 @@ export default class Upload extends Command {
           this.log(`\n${successMessage}`)
         }
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        const normalizedError = errorMessage.startsWith('Upload failed:')
+          ? errorMessage.replace(/^Upload failed:\s*/, '')
+          : errorMessage
+
+        if (!process.env.CI && process.stdout.isTTY) {
+          this.log(`\n${uploadErrorTable(normalizedError)}`)
+          this.exit(1)
+        }
+
         this.error(
-          chalk.red(`Upload failed: ${error instanceof Error ? error.message : String(error)}`),
+          chalk.red(
+            errorMessage.startsWith('Upload failed:')
+              ? errorMessage
+              : `Upload failed: ${errorMessage}`,
+          ),
         )
       }
     } catch (error) {

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -128,7 +128,7 @@ export default class Upload extends Command {
         if (isCI) {
           this.log('Upload successful!')
           this.log('Tx ID: ' + txOrManifestId)
-          if (uploadResult.size > 0) {
+          if (uploadResult.size) {
             this.log('Upload size: ' + formatUploadSize(uploadResult.size))
           }
 
@@ -152,7 +152,7 @@ export default class Upload extends Command {
           })
 
           table.push(['Tx ID', chalk.green(txOrManifestId)])
-          if (uploadResult.size > 0) {
+          if (uploadResult.size) {
             table.push(['Upload size', chalk.blue(formatUploadSize(uploadResult.size))])
           }
 

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -178,7 +178,7 @@ export default class Upload extends Command {
         const isCI = Boolean(process.env.CI)
         const bundlerLink =
           uploadCfg['uploader-type'] === 'hyperbeam' && uploadCfg.uploader
-            ? hyperbeamBundlerLink(uploadCfg.uploader, txOrManifestId)
+            ? hyperbeamBundlerLink(uploadCfg.uploader, txOrManifestId, !uploadCfg['deploy-file'])
             : undefined
 
         if (isCI) {

--- a/src/constants/flags.ts
+++ b/src/constants/flags.ts
@@ -220,6 +220,13 @@ export const globalFlags = {
       required: false,
     }),
   }),
+  useArns: createFlagConfig<boolean>({
+    flag: Flags.boolean({
+      default: false,
+      description: 'Update an ArNS/ANT record after upload.',
+      required: false,
+    }),
+  }),
   wallet: createFlagConfig<string | undefined>({
     flag: Flags.string({
       char: 'w',
@@ -262,6 +269,7 @@ export const deployFlags = {
   undername: globalFlags.undername.flag,
   uploader: globalFlags.uploader.flag,
   'uploader-type': globalFlags.uploaderType.flag,
+  'use-arns': globalFlags.useArns.flag,
   wallet: globalFlags.wallet.flag,
 }
 
@@ -289,7 +297,7 @@ export const walletFlags = {
  */
 export interface DeployConfig {
   'ario-process': string
-  'arns-name': string
+  'arns-name'?: string
   'dedupe-cache-max-entries': number
   'deploy-file'?: string
   'deploy-folder': string
@@ -306,6 +314,7 @@ export interface DeployConfig {
   'sig-type': string
   'ttl-seconds': string
   undername: string
+  'use-arns': boolean
   uploader?: string
   'uploader-type': string
   wallet?: string
@@ -336,6 +345,7 @@ export const deployFlagConfigs = {
   undername: globalFlags.undername,
   uploader: globalFlags.uploader,
   'uploader-type': globalFlags.uploaderType,
+  'use-arns': globalFlags.useArns,
   wallet: globalFlags.wallet,
 } as const
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export type SignerType = 'arweave' | 'ethereum' | 'kyve' | 'polygon'
 
 export interface DeployOptions {
   'ario-process': string
-  'arns-name': string
+  'arns-name'?: string
   'deploy-file': string
   'deploy-folder': string
   'private-key': string

--- a/src/utils/__tests__/display.test.ts
+++ b/src/utils/__tests__/display.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatUploadCost, formatUploadSize } from '../display.js'
+
+describe('formatUploadSize', () => {
+  it('formats the signed byte count when available', () => {
+    expect(formatUploadSize({ payloadBytes: 18, signedBytes: 1144 })).toBe('1,144 bytes')
+  })
+
+  it('falls back to the payload byte count', () => {
+    expect(formatUploadSize({ payloadBytes: 18 })).toBe('18 bytes')
+  })
+})
+
+describe('formatUploadCost', () => {
+  it('formats AO base units as decimal AO', () => {
+    expect(formatUploadCost({ amount: 1_347_788_856n, token: 'AO' })).toBe('0.001347788856 AO')
+  })
+})

--- a/src/utils/__tests__/hyperbeam-uploader.test.ts
+++ b/src/utils/__tests__/hyperbeam-uploader.test.ts
@@ -7,15 +7,21 @@ import {
 } from '../hyperbeam-uploader.js'
 
 describe('hyperbeamBundlerLink', () => {
-  it('builds a direct HyperBEAM raw resolver URL', () => {
+  it('builds a direct HyperBEAM item URL', () => {
     expect(hyperbeamBundlerLink('https://hyperbeam.example.com', 'abc123')).toBe(
-      'https://hyperbeam.example.com/~arweave@2.9/raw=abc123',
+      'https://hyperbeam.example.com/abc123',
     )
   })
 
   it('handles uploader URLs with trailing slashes', () => {
     expect(hyperbeamBundlerLink('https://hyperbeam.example.com/', 'abc123')).toBe(
-      'https://hyperbeam.example.com/~arweave@2.9/raw=abc123',
+      'https://hyperbeam.example.com/abc123',
+    )
+  })
+
+  it('uses an app-root URL for manifests', () => {
+    expect(hyperbeamBundlerLink('https://hyperbeam.example.com', 'abc123', true)).toBe(
+      'https://hyperbeam.example.com/abc123/',
     )
   })
 })

--- a/src/utils/__tests__/hyperbeam-uploader.test.ts
+++ b/src/utils/__tests__/hyperbeam-uploader.test.ts
@@ -42,7 +42,7 @@ describe('hyperbeamAoFundingHint', () => {
         ],
         version: 'hyperbalance@0.1',
       }),
-    ).toContain('AO (ao-mainnet): send funds to node-operator')
+    ).toContain('AO: send funds to node-operator')
   })
 })
 

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -1,3 +1,8 @@
+import boxen from 'boxen'
+import chalk from 'chalk'
+// eslint-disable-next-line import/no-named-as-default
+import Table from 'cli-table3'
+
 import type { UploadCost, UploadSize } from './hyperbeam-uploader.js'
 
 const AO_BASE_UNITS = 1_000_000_000_000n
@@ -19,4 +24,60 @@ export function formatUploadCost(cost: UploadCost): string {
       : `${whole.toString()}.${fraction.toString().padStart(12, '0').replaceAll(/0+$/g, '')}`
 
   return `${decimal} AO`
+}
+
+function fundingDisplay(section: string): string {
+  const fundingLine = section
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('- '))
+    ?.replace(/^- /, '')
+
+  if (!fundingLine) {
+    return section
+  }
+
+  return fundingLine
+    .replace(/^AO: send funds to /, 'Sending AO to ')
+    .replace(/\. Local ledger:.*$/, '')
+}
+
+export function uploadErrorTable(message: string, title = 'Upload failed'): string {
+  const table = new Table({
+    style: { head: [] },
+  })
+  const sections = message
+    .split(/\n{2,}/)
+    .map((section) => section.trim())
+    .filter(Boolean)
+
+  for (const [index, section] of sections.entries()) {
+    if (index === 0) {
+      table.push(['Error', chalk.red(section)])
+      continue
+    }
+
+    if (section.startsWith('Required upload credit:')) {
+      table.push([
+        'Required upload credit',
+        chalk.blue(section.replace(/^Required upload credit:\s*/, '')),
+      ])
+      continue
+    }
+
+    if (section.startsWith('The HyperBEAM node requires AO')) {
+      table.push(['Funding', fundingDisplay(section)])
+      continue
+    }
+
+    table.push(['Note', section])
+  }
+
+  return boxen(`${chalk.red.bold(title)}\n\n${table.toString()}`, {
+    borderColor: 'red',
+    borderStyle: 'round',
+    padding: 1,
+    title: chalk.bold('Permaweb Deploy'),
+    titleAlignment: 'center',
+  })
 }

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -1,0 +1,22 @@
+import type { UploadCost, UploadSize } from './hyperbeam-uploader.js'
+
+const AO_BASE_UNITS = 1_000_000_000_000n
+
+export function formatUploadSize(size: UploadSize): string {
+  return `${(size.signedBytes ?? size.payloadBytes).toLocaleString()} bytes`
+}
+
+export function formatUploadCost(cost: UploadCost): string {
+  if (cost.token !== 'AO') {
+    return `${cost.amount.toString()}`
+  }
+
+  const whole = cost.amount / AO_BASE_UNITS
+  const fraction = cost.amount % AO_BASE_UNITS
+  const decimal =
+    fraction === 0n
+      ? whole.toString()
+      : `${whole.toString()}.${fraction.toString().padStart(12, '0').replaceAll(/0+$/g, '')}`
+
+  return `${decimal} AO`
+}

--- a/src/utils/hyperbeam-uploader.ts
+++ b/src/utils/hyperbeam-uploader.ts
@@ -11,6 +11,8 @@ import {
   type FundingResult,
   HyperbalanceClient,
   type HyperbalanceProfile,
+  HYPERBEAM_DEFAULT_LEDGER_ID,
+  HYPERBEAM_DEFAULT_LEDGER_ROUTE,
   waitForAoAssignmentSlot,
 } from 'hyperbalance'
 
@@ -38,12 +40,31 @@ export interface UploadFileArgs {
 }
 
 export interface UploadClient {
-  uploadFile: (args: UploadFileArgs) => Promise<{ id?: string }>
+  uploadFile: (args: UploadFileArgs) => Promise<UploadClientResult>
 }
+
+export interface UploadClientResult {
+  cost?: UploadCost
+  id?: string
+  size?: UploadSize
+}
+
+export interface UploadCost {
+  amount: bigint
+  token: 'AO'
+}
+
+export interface UploadSize {
+  payloadBytes: number
+  signedBytes?: number
+}
+
+const AO_BASE_UNITS = 1_000_000_000_000n
 
 export interface HyperbeamBundlerOptions {
   autoFund?: HyperbeamBundlerAutoFundOptions
   deployKey: string
+  quote?: HyperbeamBundlerQuoteOptions
   uploadPath: string
   uploader: string
 }
@@ -66,6 +87,13 @@ export interface HyperbeamBundlerAutoFundOptions {
   deployKey: string
   ledgerId?: string
   minimumBalance?: bigint
+  quoteAction?: string
+  tokenId?: string
+  uploader: string
+}
+
+export interface HyperbeamBundlerQuoteOptions {
+  ledgerId?: string
   quoteAction?: string
   tokenId?: string
   uploader: string
@@ -129,6 +157,17 @@ export function parseHyperbeamFundAmount(value: string): bigint {
   }
 
   return BigInt(value)
+}
+
+function formatAoAmount(amount: bigint): string {
+  const whole = amount / AO_BASE_UNITS
+  const fraction = amount % AO_BASE_UNITS
+
+  if (fraction === 0n) {
+    return `${whole.toString()} AO`
+  }
+
+  return `${whole.toString()}.${fraction.toString().padStart(12, '0').replaceAll(/0+$/g, '')} AO`
 }
 
 export async function autoFundHyperbeamLedger(
@@ -226,6 +265,23 @@ export async function autoFundQuotedHyperbeamLedger(
   )
 }
 
+export async function quoteHyperbeamUpload(
+  options: { signedBytes: number } & HyperbeamBundlerQuoteOptions,
+): Promise<{ amount: bigint; ledgerId?: string; tokenId?: string }> {
+  const profile = await discoverHyperbeamAoBundlerProfile({
+    ledgerId: options.ledgerId,
+    nodeUrl: options.uploader,
+    tokenId: options.tokenId,
+  })
+  const quote = await new HyperbalanceClient({ nodeUrl: options.uploader }).quoteAuto({
+    action: options.quoteAction ?? 'hyperbeam-upload',
+    params: { bytes: options.signedBytes },
+    profile,
+  })
+
+  return { amount: quote.amount, ledgerId: quote.ledgerId, tokenId: quote.tokenId }
+}
+
 export function hyperbeamBundlerLink(uploader: string, id: string): string {
   const normalizedBase = uploader.endsWith('/') ? uploader : `${uploader}/`
   return new URL(`~arweave@2.9/raw=${encodeURIComponent(id)}`, normalizedBase).toString()
@@ -245,24 +301,50 @@ function responseId(headers: Headers, body: string): string | undefined {
   }
 }
 
+function cleanAutoFundErrorMessage(message: string): string {
+  const jsonStart = message.indexOf('{')
+  if (jsonStart >= 0) {
+    try {
+      const parsed = JSON.parse(message.slice(jsonStart)) as { error?: string }
+      if (parsed.error) {
+        return parsed.error.replace(/^Error:\s*/, '')
+      }
+    } catch {
+      // Keep the original error below if the body is not JSON.
+    }
+  }
+
+  return message
+}
+
+function autoFundFailureNote(message: string): string {
+  if (/rate limit exceeded/i.test(message)) {
+    return 'AO token transfer was rate limited. Check that the wallet has enough spendable AO before retrying auto-fund.'
+  }
+
+  return 'Check the wallet or node ledger before retrying auto-fund; the AO transfer may already have been submitted.'
+}
+
 export class HyperbeamBundlerClient implements UploadClient {
   private readonly autoFund?: HyperbeamBundlerAutoFundOptions
+  private readonly quote: HyperbeamBundlerQuoteOptions
   private readonly signer: unknown
   private readonly uploader: string
   private readonly uploadUrl: string
 
-  constructor({ autoFund, deployKey, uploadPath, uploader }: HyperbeamBundlerOptions) {
+  constructor({ autoFund, deployKey, quote, uploadPath, uploader }: HyperbeamBundlerOptions) {
     const jwk = JSON.parse(Buffer.from(deployKey, 'base64').toString('utf8')) as Record<
       string,
       unknown
     >
     this.autoFund = autoFund
+    this.quote = quote ?? { uploader }
     this.signer = new ArweaveSigner(jwk)
     this.uploader = uploader
     this.uploadUrl = normalizeUploadUrl(uploader, uploadPath)
   }
 
-  async uploadFile(args: UploadFileArgs): Promise<{ id: string }> {
+  async uploadFile(args: UploadFileArgs): Promise<{ id: string } & UploadClientResult> {
     const data = args.file
       ? typeof args.file === 'string'
         ? fs.readFileSync(args.file)
@@ -275,12 +357,42 @@ export class HyperbeamBundlerClient implements UploadClient {
 
     const raw = Buffer.from(item.getRaw())
     const localId = item.id || toBase64Url(new DataItem(raw).id)
+    const size: UploadSize = { payloadBytes: data.length, signedBytes: raw.length }
+    let cost: UploadCost | undefined
 
     if (this.autoFund) {
-      await autoFundQuotedHyperbeamLedger({
-        ...this.autoFund,
-        signedBytes: raw.length,
-      })
+      const quote = await quoteHyperbeamUpload({ ...this.quote, signedBytes: raw.length })
+      cost = { amount: quote.amount, token: 'AO' }
+      try {
+        await autoFundQuotedHyperbeamLedger({
+          ...this.autoFund,
+          ledgerId: this.autoFund.ledgerId ?? quote.ledgerId,
+          minimumBalance: this.autoFund.minimumBalance ?? quote.amount,
+          signedBytes: raw.length,
+          tokenId: this.autoFund.tokenId ?? quote.tokenId,
+        })
+      } catch (error) {
+        const message = cleanAutoFundErrorMessage(
+          error instanceof Error ? error.message : String(error),
+        )
+        throw new Error(
+          [
+            `HyperBEAM auto-fund failed: ${message}`,
+            `Required upload credit: ${formatAoAmount(cost.amount)}`,
+            autoFundFailureNote(message),
+            await this.paymentHint(false),
+          ]
+            .filter(Boolean)
+            .join('\n\n'),
+        )
+      }
+    } else {
+      try {
+        const quote = await quoteHyperbeamUpload({ ...this.quote, signedBytes: raw.length })
+        cost = { amount: quote.amount, token: 'AO' }
+      } catch {
+        cost = undefined
+      }
     }
 
     const res = await fetch(this.uploadUrl, {
@@ -306,27 +418,49 @@ export class HyperbeamBundlerClient implements UploadClient {
       )
     }
 
-    return { id: responseId(res.headers, body) || localId }
+    return { cost, id: responseId(res.headers, body) || localId, size }
   }
 
-  private async paymentHint(): Promise<string | undefined> {
+  private async paymentHint(includeAutoFundInstruction = true): Promise<string | undefined> {
     try {
       return hyperbeamAoFundingHint(
         await discoverHyperbeamAoBundlerProfile({ nodeUrl: this.uploader }),
+        { includeAutoFundInstruction },
       )
     } catch {
-      return undefined
+      try {
+        const operator = await fetch(
+          `${this.uploader.replace(/\/+$/, '')}/~meta@1.0/info/address`,
+        ).then((res) => (res.ok ? res.text() : undefined))
+        if (!operator?.trim()) return undefined
+
+        return [
+          'The HyperBEAM node requires AO in its local ledger:',
+          `- AO: send funds to ${operator.trim()}. Local ledger: ${HYPERBEAM_DEFAULT_LEDGER_ID} at ${HYPERBEAM_DEFAULT_LEDGER_ROUTE}.`,
+          includeAutoFundInstruction
+            ? 'Use --hyperbeam-auto-fund to transfer AO and import the credit automatically before upload.'
+            : undefined,
+        ]
+          .filter(Boolean)
+          .join('\n')
+      } catch {
+        return undefined
+      }
     }
   }
 }
 
-export function hyperbeamAoFundingHint(profile: HyperbalanceProfile): string | undefined {
+export function hyperbeamAoFundingHint(
+  profile: HyperbalanceProfile,
+  options: { includeAutoFundInstruction?: boolean } = {},
+): string | undefined {
   const lines = profile.tokens
     .map((token) => {
       const depositAddress = token.depositAddress ?? profile.node?.operator
       if (!depositAddress) return
 
-      const label = token.ticker ? `${token.ticker} (${token.id})` : token.id
+      const label =
+        token.ticker === 'AO' ? 'AO' : token.ticker ? `${token.ticker} (${token.id})` : token.id
       const ledger = token.ledgerId
         ? profile.ledgers.find((candidate) => candidate.id === token.ledgerId)
         : undefined
@@ -343,6 +477,10 @@ export function hyperbeamAoFundingHint(profile: HyperbalanceProfile): string | u
   return [
     'The HyperBEAM node requires AO in its local ledger:',
     ...lines,
-    'Use --hyperbeam-auto-fund to transfer AO and import the credit automatically before upload.',
-  ].join('\n')
+    options.includeAutoFundInstruction === false
+      ? undefined
+      : 'Use --hyperbeam-auto-fund to transfer AO and import the credit automatically before upload.',
+  ]
+    .filter(Boolean)
+    .join('\n')
 }

--- a/src/utils/hyperbeam-uploader.ts
+++ b/src/utils/hyperbeam-uploader.ts
@@ -171,6 +171,19 @@ function formatAoAmount(amount: bigint): string {
   return `${whole.toString()}.${fraction.toString().padStart(12, '0').replaceAll(/0+$/g, '')} AO`
 }
 
+function responsePreview(body: string): string | undefined {
+  const preview = body.replaceAll(/\s+/g, ' ').trim()
+  if (!preview) {
+    return undefined
+  }
+
+  if (/^(<!doctype html\b|<html\b)/i.test(preview)) {
+    return 'HTML error response'
+  }
+
+  return preview.slice(0, 300)
+}
+
 export async function autoFundHyperbeamLedger(
   options: HyperbeamAutoFundOptions,
 ): Promise<FundingResult> {
@@ -440,7 +453,7 @@ export class HyperbeamBundlerClient implements UploadClient {
     const body = await res.text()
 
     if (!res.ok) {
-      const preview = body.replaceAll(/\s+/g, ' ').trim().slice(0, 300)
+      const preview = responsePreview(body)
       const paymentHint = res.status === 402 ? await this.paymentHint() : undefined
       throw new Error(
         [

--- a/src/utils/hyperbeam-uploader.ts
+++ b/src/utils/hyperbeam-uploader.ts
@@ -282,9 +282,9 @@ export async function quoteHyperbeamUpload(
   return { amount: quote.amount, ledgerId: quote.ledgerId, tokenId: quote.tokenId }
 }
 
-export function hyperbeamBundlerLink(uploader: string, id: string): string {
+export function hyperbeamBundlerLink(uploader: string, id: string, isManifest = false): string {
   const normalizedBase = uploader.endsWith('/') ? uploader : `${uploader}/`
-  return new URL(`~arweave@2.9/raw=${encodeURIComponent(id)}`, normalizedBase).toString()
+  return new URL(`${encodeURIComponent(id)}${isManifest ? '/' : ''}`, normalizedBase).toString()
 }
 
 function responseId(headers: Headers, body: string): string | undefined {

--- a/src/utils/hyperbeam-uploader.ts
+++ b/src/utils/hyperbeam-uploader.ts
@@ -60,6 +60,7 @@ export interface UploadSize {
 }
 
 const AO_BASE_UNITS = 1_000_000_000_000n
+const ARWEAVE_GATEWAY = 'https://arweave.net'
 
 export interface HyperbeamBundlerOptions {
   autoFund?: HyperbeamBundlerAutoFundOptions
@@ -287,6 +288,35 @@ export function hyperbeamBundlerLink(uploader: string, id: string, isManifest = 
   return new URL(`${encodeURIComponent(id)}${isManifest ? '/' : ''}`, normalizedBase).toString()
 }
 
+async function preflightHyperbeamBundlerArBalance(uploader: string): Promise<void> {
+  const nodeUrl = uploader.replace(/\/+$/, '')
+  const addressRes = await fetch(`${nodeUrl}/~meta@1.0/info/address`)
+  if (!addressRes.ok) {
+    throw new Error(`HyperBEAM bundler address check failed with HTTP ${addressRes.status}`)
+  }
+
+  const address = (await addressRes.text()).trim()
+  if (!address) {
+    throw new Error('HyperBEAM bundler address check returned an empty address')
+  }
+
+  const balanceRes = await fetch(`${ARWEAVE_GATEWAY}/wallet/${encodeURIComponent(address)}/balance`)
+  if (!balanceRes.ok) {
+    throw new Error(`HyperBEAM bundler AR balance check failed with HTTP ${balanceRes.status}`)
+  }
+
+  const balance = (await balanceRes.text()).trim()
+  if (!/^\d+$/.test(balance)) {
+    throw new Error('HyperBEAM bundler AR balance check returned an invalid balance')
+  }
+
+  if (BigInt(balance) === 0n) {
+    throw new Error(
+      `HyperBEAM bundler wallet ${address} has 0 AR; upload aborted because the node cannot seed data to Arweave.`,
+    )
+  }
+}
+
 function responseId(headers: Headers, body: string): string | undefined {
   const headerId = headers.get('id')
   if (headerId) {
@@ -328,6 +358,7 @@ function autoFundFailureNote(message: string): string {
 export class HyperbeamBundlerClient implements UploadClient {
   private readonly autoFund?: HyperbeamBundlerAutoFundOptions
   private readonly quote: HyperbeamBundlerQuoteOptions
+  private seedPreflight?: Promise<void>
   private readonly signer: unknown
   private readonly uploader: string
   private readonly uploadUrl: string
@@ -345,6 +376,9 @@ export class HyperbeamBundlerClient implements UploadClient {
   }
 
   async uploadFile(args: UploadFileArgs): Promise<{ id: string } & UploadClientResult> {
+    this.seedPreflight ??= preflightHyperbeamBundlerArBalance(this.uploader)
+    await this.seedPreflight
+
     const data = args.file
       ? typeof args.file === 'string'
         ? fs.readFileSync(args.file)

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -13,10 +13,12 @@ import {
   touchCacheEntry,
   type TransactionCache,
 } from './cache.js'
-import type { UploadClient } from './hyperbeam-uploader.js'
+import type { UploadClient, UploadCost, UploadSize } from './hyperbeam-uploader.js'
 
 export interface UploadResult {
   cacheHit: boolean
+  cost?: UploadCost
+  size?: UploadSize
   transactionId: string
   updatedCache?: TransactionCache
 }
@@ -87,6 +89,8 @@ export async function uploadFile(
     const updatedCache = setCachedTransaction(options.cache, fileHash, uploadResult.id)
     return {
       cacheHit: false,
+      cost: uploadResult.cost,
+      size: uploadResult.size,
       transactionId: uploadResult.id,
       updatedCache,
     }
@@ -94,6 +98,8 @@ export async function uploadFile(
 
   return {
     cacheHit: false,
+    cost: uploadResult.cost,
+    size: uploadResult.size,
     transactionId: uploadResult.id,
   }
 }

--- a/src/workflows/upload-workflow.ts
+++ b/src/workflows/upload-workflow.ts
@@ -18,6 +18,8 @@ import {
   HyperbeamBundlerClient,
   parseHyperbeamFundAmount,
   type UploadClient,
+  type UploadCost,
+  type UploadSize,
 } from '../utils/hyperbeam-uploader.js'
 import { expandPath } from '../utils/path.js'
 import { createSigner } from '../utils/signer.js'
@@ -57,6 +59,12 @@ export interface UploadWorkflowIo {
   error: (msg: string) => never
 }
 
+export interface UploadWorkflowResult {
+  cost?: UploadCost
+  size?: UploadSize
+  transactionId: string
+}
+
 /**
  * Sign in to Turbo and upload a file or folder.
  *
@@ -69,7 +77,7 @@ export async function runUploadWorkflow(
   deployKey: string,
   config: UploadWorkflowConfig,
   io: UploadWorkflowIo,
-): Promise<string> {
+): Promise<UploadWorkflowResult> {
   const spinner = ora()
 
   const uploaderType = config['uploader-type'] ?? 'turbo'
@@ -107,6 +115,11 @@ export async function runUploadWorkflow(
     uploadClient = new HyperbeamBundlerClient({
       autoFund,
       deployKey,
+      quote: {
+        ledgerId: config['hyperbeam-ledger-id'],
+        tokenId: config['hyperbeam-token-id'],
+        uploader: config.uploader,
+      },
       uploadPath: config['hyperbeam-upload-path'] ?? '/~bundler@1.0/item?codec-device=ans104@1.0',
       uploader: config.uploader,
     })
@@ -205,6 +218,8 @@ export async function runUploadWorkflow(
   }
 
   let txOrManifestId: string
+  let cost: UploadCost | undefined
+  let size: UploadSize | undefined
   try {
     if (config['deploy-file']) {
       const filePath = expandPath(config['deploy-file'])
@@ -219,6 +234,8 @@ export async function runUploadWorkflow(
       }
 
       txOrManifestId = uploadResult.transactionId
+      cost = uploadResult.cost
+      size = uploadResult.size
 
       if (uploadResult.updatedCache && config['dedupe-cache-max-entries'] > 0) {
         cache = cleanupCache(uploadResult.updatedCache, config['dedupe-cache-max-entries'])
@@ -250,6 +267,8 @@ export async function runUploadWorkflow(
       }
 
       txOrManifestId = uploadResult.transactionId
+      cost = uploadResult.cost
+      size = uploadResult.size
 
       if (uploadResult.updatedCache && config['dedupe-cache-max-entries'] > 0) {
         cache = cleanupCache(uploadResult.updatedCache, config['dedupe-cache-max-entries'])
@@ -278,5 +297,9 @@ export async function runUploadWorkflow(
     io.error(`Upload failed: ${errorMessage}`)
   }
 
-  return txOrManifestId
+  return {
+    cost,
+    size,
+    transactionId: txOrManifestId,
+  }
 }

--- a/tests/e2e/deploy-command.test.ts
+++ b/tests/e2e/deploy-command.test.ts
@@ -1,6 +1,6 @@
 import { runCommand } from '@oclif/test'
 import { http, HttpResponse } from 'msw'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { TEST_ETH_PRIVATE_KEY } from '../constants.js'
 import { mockInsufficientBalance } from '../mocks/turbo-handlers.js'
@@ -9,18 +9,6 @@ import { server } from '../setup.js'
 describe(
   'deploy command',
   () => {
-    beforeAll(() => {
-      server.listen({ onUnhandledRequest: 'warn' })
-    })
-
-    afterEach(() => {
-      server.resetHandlers()
-    })
-
-    afterAll(() => {
-      server.close()
-    })
-
     it('should show deploy help message', async () => {
       const result = await runCommand(['deploy', '--help'])
       expect(result.error).toBeUndefined()

--- a/tests/e2e/deploy-command.test.ts
+++ b/tests/e2e/deploy-command.test.ts
@@ -31,6 +31,19 @@ describe(
       expect(result.error).toBeUndefined()
     })
 
+    it('should deploy without requiring ArNS by default', async () => {
+      const result = await runCommand([
+        'deploy',
+        '--deploy-file',
+        './tests/fixtures/test-app/index.html',
+        '--wallet',
+        './tests/fixtures/test_wallet.json',
+        '--no-dedupe',
+      ])
+
+      expect(result.error).toBeUndefined()
+    })
+
     it('should validate on-demand token options', async () => {
       const { error } = await runCommand([
         'deploy',

--- a/tests/e2e/deploy-command.test.ts
+++ b/tests/e2e/deploy-command.test.ts
@@ -1,6 +1,6 @@
 import { runCommand } from '@oclif/test'
 import { http, HttpResponse } from 'msw'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { TEST_ETH_PRIVATE_KEY } from '../constants.js'
 import { mockInsufficientBalance } from '../mocks/turbo-handlers.js'
@@ -157,6 +157,23 @@ describe(
     })
 
     describe('hyperbeam uploader', () => {
+      beforeEach(() => {
+        server.use(
+          http.get('https://hyperbeam.test/~meta@1.0/info/address', () =>
+            HttpResponse.text('node-deposit-address'),
+          ),
+          http.get('https://hyperbeam.test/~meta@1.0/info/ao-payment-deposit-address', () =>
+            HttpResponse.text('node-deposit-address'),
+          ),
+          http.get('https://arweave.net/wallet/node-deposit-address/balance', () =>
+            HttpResponse.text('1'),
+          ),
+          http.get('https://hyperbeam.test/~arweave-byte-pricing@1.0/quote', () =>
+            HttpResponse.text('1000'),
+          ),
+        )
+      })
+
       it('should upload a file through a HyperBEAM bundler route', async () => {
         const seenUploads: Array<{ contentType: string; size: number }> = []
 
@@ -211,9 +228,6 @@ describe(
 
       it('should include AO funding metadata when a HyperBEAM upload needs payment', async () => {
         server.use(
-          http.get('https://hyperbeam.test/~meta@1.0/info/address', () =>
-            HttpResponse.text('node-deposit-address'),
-          ),
           http.post('https://hyperbeam.test/~bundler@1.0/item', () =>
             HttpResponse.text('insufficient local ledger balance', { status: 402 }),
           ),
@@ -235,6 +249,38 @@ describe(
         expect(result.error).toBeDefined()
         expect(result.error?.message).toContain('node-deposit-address')
         expect(result.error?.message).toContain('default')
+      })
+
+      it('should reject HyperBEAM uploads when the bundler wallet has no AR', async () => {
+        let uploadAttempted = false
+
+        server.use(
+          http.get('https://arweave.net/wallet/node-deposit-address/balance', () =>
+            HttpResponse.text('0'),
+          ),
+          http.post('https://hyperbeam.test/~bundler@1.0/item', () => {
+            uploadAttempted = true
+            return HttpResponse.text('should not upload', { status: 200 })
+          }),
+        )
+
+        const result = await runCommand([
+          'upload',
+          '--deploy-file',
+          './tests/fixtures/test-app/index.html',
+          '--wallet',
+          './tests/fixtures/test_wallet.json',
+          '--uploader-type',
+          'hyperbeam',
+          '--uploader',
+          'https://hyperbeam.test',
+          '--no-dedupe',
+        ])
+
+        expect(result.error).toBeDefined()
+        expect(result.error?.message).toContain('has 0 AR')
+        expect(result.error?.message).toContain('cannot seed data to Arweave')
+        expect(uploadAttempted).toBe(false)
       })
     })
 


### PR DESCRIPTION
  ## about
  
  - make `deploy` publish to Arweave by default without requiring having ArNS - direct manifests 
  - adds `--use-arns` for the existing ArNS update flow, with `--arns-name` still supported for compatibility (as is path)
  - improves hyperbeam  shell output (bundler url, upload size/cost bytes/AO, cleaner errors)
  - add hyperbeam bundler operator AR balance preflight before upload (~meta@1.0/info/address AR balance))
  - update tests/docs and fix some CI lints


<img width="1365" height="897" alt="image" src="https://github.com/user-attachments/assets/3af4545b-115a-448d-9910-55bc63ec5d1f" />

<img width="1365" height="756" alt="image" src="https://github.com/user-attachments/assets/335e3654-835e-42eb-9100-447ef93bacaa" />

<img width="1280" height="469" alt="image" src="https://github.com/user-attachments/assets/e21877ff-741f-40ec-be11-d68071ed14e9" />